### PR TITLE
Dependency updates and more

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var marked = require('marked');
-var highlight = require('highlight-codemirror');
 var katex = require('katex');
 var entities = require("entities");
 
@@ -13,7 +12,6 @@ var defaults = {
   sanitize: true,
   smartLists: true,
   silent: false,
-  highlight: null,
   langPrefix: 'cm-s-default lang-',
   smartypants: false,
   headerPrefix: '',
@@ -54,21 +52,6 @@ function supermarked(src, options) {
       options[key] = defaults[key];
     }
   });
-
-  var aliases = options.aliases || supermarked.aliases;
-  if (options.highlight !== false && typeof options.highlight !== 'function') {
-    options.highlight = function (code, lang) {
-      if (lang) {
-        try {
-          var mode = aliases[lang.toLowerCase()] || lang.toLowerCase();
-          highlight.loadMode(mode);
-          return highlight(code, mode);
-        } catch (ex) {
-          throw ex;
-        } //let marked automatically escape code in a language we don't speak
-      }
-    };
-  }
 
   if (options.math !== false) {
     options.renderer = new marked.Renderer();
@@ -136,8 +119,4 @@ var services = supermarked.services = {
   'github': 'https://github.com/:user:',
   'npm': 'https://www.npmjs.org/~:user:',
   'facebook': 'https://www.facebook.com/:user:'
-};
-
-var alises = supermarked.aliases = {
-  'js': 'javascript'
 };

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var marked = require('marked');
 var highlight = require('highlight-codemirror');
 var katex = require('katex');
+var entities = require("entities");
 
 var defaults = {
   gfm: true,
@@ -27,10 +28,7 @@ function renderMathsExpression(expr) {
       displayStyle = true;
       expr = '\\displaystyle ' + expr.substr(1, expr.length - 2);
     }
-    var html = katex.renderToString(expr);
-    if (displayStyle) {
-      html = html.replace(/class=\"katex\"/g, 'class="katex katex-block" style="display: block;"');
-    }
+    var html = katex.renderToString(entities.decodeHTML(expr), displayStyle);
     return html;
   } else {
     return null;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "supermarked",
   "version": "2.0.0",
-  "description": "Marked with syntax highlighting and ascii-math by default",
+  "description": "Marked with ascii-math by default",
   "main": "index.js",
   "dependencies": {
-    "highlight-codemirror": "^4.6.1",
     "katex": "^0.2.0",
     "marked": "^0.3.3",
     "entities": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "dependencies": {
     "highlight-codemirror": "^4.6.1",
-    "katex": "^0.1.1",
-    "marked": "~0.3.2"
+    "katex": "^0.2.0",
+    "marked": "^0.3.3",
+    "entities": "^1.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Updated KaTeX to 2.0, marked to 3.3 and also added entities for HTML decoding which was causing issues in math equations that contains less-than or greater-than signs that had to be encoded.
